### PR TITLE
[#16] 웹 콘텐츠 네이티브 공유 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,98 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+.swiftpm/
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the CocoaPods dependencies.
+# Pods/
+# Uncomment the next line to ignore pods dependencies
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+# Mac
+.DS_Store
+/.idea/
+/.rules/
+/.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Climingo-app is a SwiftUI-based iOS application that wraps a web app (app.climingo.xyz) in a native WebView. The app includes environment switching capabilities and social sharing features.
+
+## Architecture
+
+- **Main App**: `climingo_appApp.swift` - SwiftUI app entry point
+- **ContentView**: Main view containing WebView with embedded JavaScript bridge for sharing
+- **WebView**: UIViewRepresentable wrapper for WKWebView with custom navigation and script message handling
+- **DeveloperModeView**: Hidden developer interface for switching between environments (dev/stg/prd)
+- **Developer Access**: Hidden tap gesture (7 taps on top center) with password authentication ("climb_dev")
+
+## Build Commands
+
+```bash
+# Build project
+xcodebuild -project climingo-app.xcodeproj -scheme climingo-app -destination 'platform=iOS Simulator,name=iPhone 15' build
+
+# Run tests
+xcodebuild test -project climingo-app.xcodeproj -scheme climingo-app -destination 'platform=iOS Simulator,name=iPhone 15'
+
+# Clean build
+xcodebuild -project climingo-app.xcodeproj -scheme climingo-app clean
+```
+
+## Key Features
+
+- **WebView Configuration**: Allows inline media playback, disables user action requirement for media
+- **JavaScript Bridge**: Handles "share" messages from web content via WKScriptMessageHandler
+- **Native Sharing**: UIActivityViewController integration for web content sharing
+- **Environment Switching**: Dev/Staging/Production URL switching through developer mode
+- **State Persistence**: Current URL saved to UserDefaults
+
+## Development Notes
+
+- App defaults to production URL: `https://app.climingo.xyz`
+- Developer mode URLs:
+  - Dev: `https://dev-app.climingo.xyz`  
+  - Staging: `https://stg-app.climingo.xyz`
+  - Production: `https://app.climingo.xyz`
+- App terminates (exit(0)) when switching environments to force restart
+- WebView includes 2-second sleep delay on initialization
+- Korean language used in UI alerts and messages
+
+## Development Guidelines
+
+프로젝트 개발 시 다음 `.rules/` 디렉토리의 파일들을 참조하세요:
+
+### 📋 General Coding Rules
+- **파일**: `.rules/general.md`
+- **내용**: 언어 및 명명 규칙, 코드 스타일, 주석 가이드라인, 타입 안전성, 함수 작성, 에러 처리, 성능 최적화
+
+### 🔒 Security Rules  
+- **파일**: `.rules/security.md`
+- **내용**: 민감 정보 보호, XSS 방지, CSRF 방지, 인증 및 권한 관리, 입력 검증, 개인정보 보호
+
+### 🏛️ Architecture Guidelines
+- **파일**: `.rules/architecture.md` 
+- **내용**: 아키텍처, 레이어 구조, 의존성 방향
+
+### 🧪 Testing Rules
+- **파일**: `.rules/test.md`
+- **내용**: 테스트 명명 규칙, AAA 패턴, Locator 우선순위, 비동기 처리, Mock 선언, 프로젝트별 테스트 구조
+
+### 📝 Commit Message Convention
+- **파일**: `.rules/commit.md`
+- **내용**: 커밋 메시지 구조, 커밋 타입, 스코프, 브랜치명과 일감번호 매핑, 프로젝트별 특수 규칙


### PR DESCRIPTION
## Summary

웹 앱에서 네이티브 공유 기능을 사용할 수 있도록 JavaScript 브리지를 구현했습니다.

### 주요 변경사항
- **JavaScript 메시지 핸들러**: 웹에서 `share` 이벤트를 수신하는 WKScriptMessageHandler 구현
- **다양한 공유 데이터 형식 지원**: 텍스트, URL, 제목을 포함한 복합 데이터 처리
- **iPad 지원**: popover를 통한 태블릿 최적화 인터페이스
- **Fallback 메시지**: 공유 데이터가 없을 때 기본 Climingo 메시지 제공

### 기술적 구현
- `WKUserContentController`를 통한 JavaScript-네이티브 통신
- `UIActivityViewController`를 사용한 시스템 공유 인터페이스
- 다양한 데이터 타입 파싱 및 조합 로직

## Test Plan

- [ ] 웹에서 JavaScript를 통한 공유 기능 테스트
- [ ] 텍스트만 공유하는 경우 테스트
- [ ] URL만 공유하는 경우 테스트  
- [ ] 텍스트 + URL 조합 공유 테스트
- [ ] 제목 + 텍스트 + URL 조합 공유 테스트
- [ ] iPad에서 popover 동작 확인
- [ ] 공유 데이터가 없을 때 fallback 메시지 확인
- [ ] 다양한 공유 앱(메시지, 카카오톡, 트위터 등)에서 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)